### PR TITLE
Fix the parsing of the now playing options

### DIFF
--- a/src/pages/NowPlaying.vue
+++ b/src/pages/NowPlaying.vue
@@ -25,9 +25,9 @@ export default {
   mounted () {
     const { showArtist, showAlbumArt, showSpotifyLogo, accessToken } = this.$route.query
 
-    this.showArtist = Boolean(showArtist)
-    this.showAlbumArt = Boolean(showAlbumArt)
-    this.showSpotifyLogo = Boolean(showSpotifyLogo)
+    this.showArtist = showArtist === "true"
+    this.showAlbumArt = showAlbumArt === "true"
+    this.showSpotifyLogo = showSpotifyLogo === "true"
     this.accessToken = accessToken
   }
 }


### PR DESCRIPTION
`false` in a query string is returned as a string, meaning `Boolean("false")` returns `true`.

Fixes #35 and fixes #36